### PR TITLE
Add invitePriorityQuest trigger

### DIFF
--- a/automations/invitePriorityQuest.gs
+++ b/automations/invitePriorityQuest.gs
@@ -1,0 +1,135 @@
+/**
+ * invitePriorityQuest()
+ *
+ * Chooses the quest scroll with the lowest party completion percentage
+ * from the player's inventory and invites their party to the quest.
+ * If EXCLUDE_GEM_QUESTS = true, gem quest scrolls are ignored.
+ * If EXCLUDE_HOURGLASS_QUESTS = true, hourglass quest scrolls are ignored.
+ *
+ * Run this function 5-15 mins after the party finishes a quest. The
+ * randomized delay allows party members without scripts to run quests
+ * too, and prevents multiple "invite quest" requests from hitting
+ * Habitica's servers at once.
+ */
+function invitePriorityQuest() {
+  try {
+    // delete temporary trigger
+    for (let trigger of ScriptApp.getProjectTriggers()) {
+      if (trigger.getHandlerFunction() === "invitePriorityQuest") {
+        ScriptApp.deleteTrigger(trigger);
+      }
+    }
+
+    // if not in a party or party is on a quest, return
+    if (
+      typeof getParty(true) === "undefined" ||
+      typeof party.quest.key !== "undefined"
+    ) {
+      return;
+    }
+
+    // get quest completion data for the party
+    let questCompletionData = getQuestCompletionData();
+
+    // for each quest scroll the player owns
+    let availableQuests = [];
+    for (let [questKey, numScrolls] of Object.entries(getUser().items.quests)) {
+      if (numScrolls > 0) {
+        // if not excluded by settings
+        let category = getContent().quests[questKey].category;
+        if (
+          (AUTO_INVITE_HOURGLASS_QUESTS === true &&
+            category === "timeTravelers") ||
+          (category != "timeTravelers" &&
+            ((AUTO_INVITE_GOLD_QUESTS === true &&
+              typeof content.quests[questKey].goldValue !== "undefined") ||
+              (AUTO_INVITE_UNLOCKABLE_QUESTS === true &&
+                category === "unlockable") ||
+              (AUTO_INVITE_PET_QUESTS === true &&
+                ["pet", "hatchingPotion"].includes(category))))
+        ) {
+          // find the quest in completion data
+          let questCompletion = questCompletionData.find(
+            (q) => q.questKey === questKey
+          );
+
+          if (questCompletion) {
+            availableQuests.push({
+              questKey: questKey,
+              numScrolls: numScrolls,
+              completionPercentage: questCompletion.completionPercentage,
+              questName: content.quests[questKey].text,
+            });
+          } else {
+            // quest not found in completion data (e.g., world boss), add with 0% completion
+            availableQuests.push({
+              questKey: questKey,
+              numScrolls: numScrolls,
+              completionPercentage: 0,
+              questName: content.quests[questKey].text,
+            });
+          }
+        }
+      }
+    }
+
+    // if list contains scrolls
+    if (availableQuests.length > 0) {
+      // sort by completion percentage (lowest first)
+      availableQuests.sort(
+        (a, b) => a.completionPercentage - b.completionPercentage
+      );
+
+      // select the quest with the lowest completion percentage
+      let selectedQuest = availableQuests[0];
+
+      console.log(
+        "Inviting party to " +
+          selectedQuest.questName +
+          " (completion: " +
+          Math.floor(selectedQuest.completionPercentage) +
+          "%)"
+      );
+
+      // invite party to the selected quest
+      fetch(
+        "https://habitica.com/api/v3/groups/party/quests/invite/" +
+          selectedQuest.questKey,
+        POST_PARAMS
+      );
+
+      scriptProperties.deleteProperty("QUEST_SCROLL_PM_SENT");
+    }
+
+    // send player a PM if they are out of usable quest scrolls
+    if (
+      PM_WHEN_OUT_OF_QUEST_SCROLLS === true &&
+      availableQuests.length <= 1 &&
+      scriptProperties.getProperty("QUEST_SCROLL_PM_SENT") === null
+    ) {
+      console.log("No more usable quest scrolls, sending PM to player");
+
+      let params = Object.assign(
+        {
+          contentType: "application/json",
+          payload: JSON.stringify({
+            message: "You have no more usable quest scrolls!",
+            toUserId: USER_ID,
+          }),
+        },
+        POST_PARAMS
+      );
+      fetch("https://habitica.com/api/v3/members/send-private-message", params);
+
+      scriptProperties.setProperty("QUEST_SCROLL_PM_SENT", "true");
+    }
+  } catch (e) {
+    MailApp.sendEmail(
+      Session.getEffectiveUser().getEmail(),
+      DriveApp.getFileById(ScriptApp.getScriptId()).getName() + " failed!",
+      e.stack
+    );
+    console.error(e.stack);
+    throw e;
+  }
+}

--- a/automations/invitePriorityQuest.gs
+++ b/automations/invitePriorityQuest.gs
@@ -73,6 +73,31 @@ function invitePriorityQuest() {
       }
     }
 
+    // log all quests with completion percentages (for debugging)
+    let userQuestScrolls = new Set(
+      Object.keys(getUser().items.quests).filter(
+        (q) => getUser().items.quests[q] > 0
+      )
+    );
+
+    // sort all quest completion data by percentage
+    questCompletionData.sort(
+      (a, b) => a.completionPercentage - b.completionPercentage
+    );
+
+    console.log("=== Quest Completion Data (sorted by %) ===");
+    for (let quest of questCompletionData) {
+      let hasScroll = userQuestScrolls.has(quest.questKey) ? " *" : "";
+      console.log(
+        Math.floor(quest.completionPercentage).toString().padStart(3) +
+          "% - " +
+          quest.questName +
+          hasScroll
+      );
+    }
+    console.log("(* = you have a scroll for this quest)");
+    console.log("==========================================");
+
     // if list contains scrolls
     if (availableQuests.length > 0) {
       // sort by completion percentage (lowest first)
@@ -84,7 +109,7 @@ function invitePriorityQuest() {
       let selectedQuest = availableQuests[0];
 
       console.log(
-        "Inviting party to " +
+        "Selected: " +
           selectedQuest.questName +
           " (completion: " +
           Math.floor(selectedQuest.completionPercentage) +

--- a/setup.gs
+++ b/setup.gs
@@ -21,6 +21,7 @@ const AUTO_INVITE_GOLD_QUESTS = false;
 const AUTO_INVITE_UNLOCKABLE_QUESTS = false;
 const AUTO_INVITE_PET_QUESTS = false;
 const AUTO_INVITE_HOURGLASS_QUESTS = false;
+const QUEST_INVITE_MODE = "priority"; // "random" or "priority" (priority selects quest with lowest party completion %)
 const PM_WHEN_OUT_OF_QUEST_SCROLLS = true;
 
 const NOTIFY_ON_QUEST_END = true;
@@ -210,9 +211,26 @@ function validateConstants() {
     valid = false;
   }
 
-  if (AUTO_INVITE_GOLD_QUESTS === true || AUTO_INVITE_UNLOCKABLE_QUESTS === true || AUTO_INVITE_PET_QUESTS === true || AUTO_INVITE_HOURGLASS_QUESTS === true) {
-    if (PM_WHEN_OUT_OF_QUEST_SCROLLS !== true && PM_WHEN_OUT_OF_QUEST_SCROLLS !== false) {
-      console.log("ERROR: PM_WHEN_OUT_OF_QUEST_SCROLLS must equal either true or false.\n\neg. const PM_WHEN_OUT_OF_QUEST_SCROLLS = true;\n    const PM_WHEN_OUT_OF_QUEST_SCROLLS = false;");
+  if (
+    AUTO_INVITE_GOLD_QUESTS === true ||
+    AUTO_INVITE_UNLOCKABLE_QUESTS === true ||
+    AUTO_INVITE_PET_QUESTS === true ||
+    AUTO_INVITE_HOURGLASS_QUESTS === true
+  ) {
+    if (QUEST_INVITE_MODE !== "random" && QUEST_INVITE_MODE !== "priority") {
+      console.log(
+        'ERROR: QUEST_INVITE_MODE must equal either "random" or "priority".\n\neg. const QUEST_INVITE_MODE = "random";\n    const QUEST_INVITE_MODE = "priority";'
+      );
+      valid = false;
+    }
+
+    if (
+      PM_WHEN_OUT_OF_QUEST_SCROLLS !== true &&
+      PM_WHEN_OUT_OF_QUEST_SCROLLS !== false
+    ) {
+      console.log(
+        "ERROR: PM_WHEN_OUT_OF_QUEST_SCROLLS must equal either true or false.\n\neg. const PM_WHEN_OUT_OF_QUEST_SCROLLS = true;\n    const PM_WHEN_OUT_OF_QUEST_SCROLLS = false;"
+      );
       valid = false;
     }
   }


### PR DESCRIPTION
This PR adds a new auto quest invite function that prioritizes sending invites to quests which the party has completed the least.

It addresses the topics mentioned in discussion #47.

1. Quest information is gathered.
2. "Party quest completion percentage" (taken from quest-tracker) is computed.
3. Quests are sorted in ascending order of completion %.
4. The first quest which the player has a scroll for is used.

The README may need an update to detail how to use this. If the change is welcome, I can do it as well.