### PR TITLE
Remove permission for full Google Drive access

### DIFF
--- a/automations/hideNotifications.gs
+++ b/automations/hideNotifications.gs
@@ -82,7 +82,7 @@ function hidePartyNotification() {
   } catch (e) {
     MailApp.sendEmail(
       Session.getEffectiveUser().getEmail(),
-      DriveApp.getFileById(ScriptApp.getScriptId()).getName() + " failed!",
+      PROJECT_NAME + " failed!",
       e.stack
     );
     console.error(e.stack);

--- a/automations/inviteRandomQuest.gs
+++ b/automations/inviteRandomQuest.gs
@@ -76,7 +76,7 @@ function inviteRandomQuest() {
   } catch (e) {
     MailApp.sendEmail(
       Session.getEffectiveUser().getEmail(),
-      DriveApp.getFileById(ScriptApp.getScriptId()).getName() + " failed!",
+      PROJECT_NAME + " failed!",
       e.stack
     );
     console.error(e.stack);

--- a/global.gs
+++ b/global.gs
@@ -33,7 +33,7 @@ function onTrigger() {
   } catch (e) {
     MailApp.sendEmail(
       Session.getEffectiveUser().getEmail(),
-      DriveApp.getFileById(ScriptApp.getScriptId()).getName() + " failed!",
+      PROJECT_NAME + " failed!",
       e.stack
     );
     console.error(e.stack);
@@ -95,7 +95,7 @@ function doPost(e) {
     if (!e.stack.includes("Address unavailable")) {
       MailApp.sendEmail(
         Session.getEffectiveUser().getEmail(),
-        DriveApp.getFileById(ScriptApp.getScriptId()).getName() + " failed!",
+        PROJECT_NAME + " failed!",
         e.stack
       );
       console.error(e.stack);

--- a/setup.gs
+++ b/setup.gs
@@ -8,6 +8,7 @@
 const USER_ID = "";
 const API_TOKEN = "";
 const WEB_APP_URL = "";
+const PROJECT_NAME = "Automate Habitica";
 
 const AUTO_CRON = false; // true or false
 
@@ -511,7 +512,7 @@ function createWebhooks(groupChatReceived) {
     for (let webhook of webhooks) {
       webhook = Object.assign({
         "url": WEB_APP_URL,
-        "label": DriveApp.getFileById(ScriptApp.getScriptId()).getName()
+        "label": PROJECT_NAME
       }, webhook);
       webhook = Object.assign({
         "contentType": "application/json",


### PR DESCRIPTION
Some users, like myself in the beginning, get startled when the script asks for full read-only access to the users Google Drive.

The permission comes with a frightening warning about the service being able to download all of the user's content, which includes medical and financial records etc.

So in this PR, I tracked the reason why Automate Habitica needs GDrive access and circumvented it. It turns out it accesses GDrive just to get the project name, `"Automate Habitica"`.

I just created a global string with the value and referenced it throughout the code.

It does not ask for GDrive permission anymore.